### PR TITLE
Criada a função `obter_arquivos_arrec()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,18 +23,18 @@ BugReports: https://github.com/cccneto/Ibamam/issues
 Depends: 
     R (>= 3.6)
 Imports: 
-    dplyr,
-    glue,
-    httr,
-    jsonlite,
-    tibble,
-    geobr,
-    stringr,
     abjutils,
     deflateBR,
-    purrr,
-    tidyverse,
-    magrittr,
+    dplyr,
+    geobr,
+    glue,
+    httr,  
+    jsonlite,
     lubridate,
+    magrittr,
     methods,
+    purrr,
+    stringr,
+    tibble,
+    tidyverse,
     usethis

--- a/Ibamam.Rproj
+++ b/Ibamam.Rproj
@@ -14,7 +14,6 @@ LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
-LineEndingConversion: Posix
 
 BuildType: Package
 PackageUseDevtools: Yes

--- a/R/obter_arquivos_arrec.R
+++ b/R/obter_arquivos_arrec.R
@@ -1,0 +1,26 @@
+#' @title Downloading data from Ibama database - Multas
+#'
+#' @param ufs bla bla bla
+#' @param path Path where the jason files will be saved.
+#'
+#' @return a data frame
+#'
+#' @export
+obter_arquivos_arrec <- function() {
+  purrr::map_dfr(
+    unique(geobr::grid_state_correspondence_table$code_state),
+    raspar_arquivos_arrec
+  )
+
+}
+
+raspar_arquivos_arrec <- function(uf){
+  arrec <- jsonlite::fromJSON(
+      paste0(
+        "http://dadosabertos.ibama.gov.br/dados/SICAFI/", uf,
+        "/Arrecadacao/arrecadacaobenstutelados.json"
+      )
+  )
+
+  dplyr::as_tibble(arrec$data)
+}


### PR DESCRIPTION
Agora a função não precisa mais baixar os arquivos e raspa toda informação direto do site ibama